### PR TITLE
Fix papercuts involving proxy usage

### DIFF
--- a/abot-epc-basic/hooks/install
+++ b/abot-epc-basic/hooks/install
@@ -30,10 +30,12 @@ apt-get -y install maven
 juju-log "Maven installation done."
 
 #Download the ABOT package and install it
-wget $abot_epc_basic_url
+if [[ ! -f "$CHARM_DIR/payload/$abot_epc_basic_package_name" ]]; then
+    wget $abot_epc_basic_url/$abot_epc_basic_package_name -O $CHARM_DIR/payload/$abot_epc_basic_package_name
+fi
 
 #Install the package using dpkg
-dpkg --install  $abot_epc_basic_package_name
+dpkg --install $CHARM_DIR/payload/$abot_ims_basic_package_name
 juju-log "Install abot package completed ..."
 
 

--- a/abot-ims-basic/hooks/install
+++ b/abot-ims-basic/hooks/install
@@ -30,19 +30,21 @@ cd $CHARM_DIR/lib/
 . scripts/install_java
 juju-log "Java Installed."
 
-#Dependencies for abot-ims-basic 
-apt-get -y install apache2
+#Dependencies for abot-ims-basic
+apt-get -y install apache2 oracle-java8-set-default
 
-juju-log "Instlling Maven..."
-apt-get update
+juju-log "Installing Maven..."
 apt-get -y install maven
+
 juju-log "Maven installation done."
 
 #Download the ABOT package and install it
-wget $abot_ims_basic_url/$abot_ims_basic_package_name
+if [[ ! -f "$CHARM_DIR/payload/$abot_ims_basic_package_name" ]]; then
+    wget $abot_ims_basic_url/$abot_ims_basic_package_name -O $CHARM_DIR/payload/$abot_ims_basic_package_name
+fi
 
 #Install the package using dpkg
-dpkg --install  $abot_ims_basic_package_name
+dpkg --install $CHARM_DIR/payload/$abot_ims_basic_package_name
 juju-log "Install abot package completed ..."
 
 
@@ -57,7 +59,11 @@ juju-log "SIPP installation done."
 juju-log "Downloading Sipp"
 
 cd /home/ubuntu
-wget $sipp_url
+if [[ -f $CHARM_DIR/payload/sip-3.3.tar.gz ]]; then
+    cp $CHARM_DIR/payload/sip-3.3.tar.gz /home/ubuntu
+else
+    wget $sipp_url
+fi
 
 tar -xvzf sipp-3.3.tar.gz
 
@@ -101,7 +107,7 @@ ln -s $CHARM_DIR/lib/config $DIR/config
 ln -s $CHARM_DIR/lib/jar $DIR/jar
 ln -s $CHARM_DIR/lib/scenarios $DIR/scenarios
 
-#Change permissions of the charm/lib folders 
+#Change permissions of the charm/lib folders
 chown -R ubuntu:ubuntu $CHARM_DIR/lib
 
 mkdir -p $DIR/tags

--- a/abot-ims-basic/lib/scripts/install_java
+++ b/abot-ims-basic/lib/scripts/install_java
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-add-apt-repository ppa:webupd8team/java
+# Fix prompt to confirm repo key
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+
+add-apt-repository -y ppa:webupd8team/java
 apt-get update
 echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
 echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections

--- a/clearwater-bono/lib/chef_solo_install
+++ b/clearwater-bono/lib/chef_solo_install
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Configure git proxy
+if [[ ! -z $http_proxy ]]; then
+    juju-log "Configuring git proxy..."
+    git config --global http.proxy $http_proxy
+fi
+
 # This covers installing chef-solo and the Clearwater chef recipes
 # Install chef and needed tools/libraries
 apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
@@ -7,11 +13,13 @@ apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
 # Pull down the Clearwater chef recipes
 if [ ! -d /home/ubuntu/chef-solo ]
 then
+  juju-log "Cloning Clearwater/chef recipes..."
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive https://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
+juju-log "Updating chef recipes..."
 cd /home/ubuntu/chef-solo
 git checkout release-110
 git submodule update --init

--- a/clearwater-homestead/lib/chef_solo_install
+++ b/clearwater-homestead/lib/chef_solo_install
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Configure git proxy
+if [[ ! -z $http_proxy ]]; then
+    juju-log "Configuring git proxy..."
+    git config --global http.proxy $http_proxy
+fi
+
 # This covers installing chef-solo and the Clearwater chef recipes
 # Install chef and needed tools/libraries
 apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
@@ -7,11 +13,13 @@ apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
 # Pull down the Clearwater chef recipes
 if [ ! -d /home/ubuntu/chef-solo ]
 then
+  juju-log "Cloning Clearwater/chef recipes..."
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive https://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
+juju-log "Updating chef recipes..."
 cd /home/ubuntu/chef-solo
 git checkout release-110
 git submodule update --init

--- a/clearwater-sprout/lib/chef_solo_install
+++ b/clearwater-sprout/lib/chef_solo_install
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Configure git proxy
+if [[ ! -z $http_proxy ]]; then
+    juju-log "Configuring git proxy..."
+    git config --global http.proxy $http_proxy
+fi
+
 # This covers installing chef-solo and the Clearwater chef recipes
 # Install chef and needed tools/libraries
 apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
@@ -7,11 +13,13 @@ apt-get -y install chef git libxml2-dev libxslt1-dev wget curl
 # Pull down the Clearwater chef recipes
 if [ ! -d /home/ubuntu/chef-solo ]
 then
+  juju-log "Cloning Clearwater/chef recipes..."
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive https://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
+juju-log "Updating chef recipes..."
 cd /home/ubuntu/chef-solo
 git checkout release-110
 git submodule update --init


### PR DESCRIPTION
The Juju environment will have the variables http_proxy, https_proxy, HTTP_PROXY, and HTTPS_PROXY 
set automatically if it has been configured to use a proxy server. Most of the changes I made to work were due to this.

I also worked around the proxy issue by "fat packing" the charm, i.e., putting the external resources into the "payload" directory, allowing the script to deploy in an offline mode.